### PR TITLE
chore: add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-MIT License
+﻿MIT License
 
-Copyright (c) 2026 maitamdev
+Copyright (c) 2026 MaiTamDev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Adds MIT License file to properly license the project as open source.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add MIT License to open‑source the project and set the copyright notice to `MaiTamDev` (2026).

<sup>Written for commit 15d593158986833151f8b4e74e83145e0fad7206. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

